### PR TITLE
Fix Acess modifiers as part of extending ServicestateTracker.

### DIFF
--- a/src/java/com/android/internal/telephony/ServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/ServiceStateTracker.java
@@ -368,7 +368,7 @@ public class ServiceStateTracker extends Handler {
     };
 
     //Common
-    private GsmCdmaPhone mPhone;
+    protected GsmCdmaPhone mPhone;
     public CellLocation mCellLoc;
     private CellLocation mNewCellLoc;
     public static final int MS_PER_HOUR = 60 * 60 * 1000;
@@ -1805,7 +1805,7 @@ public class ServiceStateTracker extends Handler {
         }
     }
 
-    void handlePollStateResultMessage(int what, AsyncResult ar) {
+    protected void handlePollStateResultMessage(int what, AsyncResult ar) {
         int ints[];
         switch (what) {
             case EVENT_POLL_STATE_REGISTRATION: {


### PR DESCRIPTION
In the process of extending ServicestateTracker class to
QtiServiceStateTracker, Modify Access modifier types of
few variables and method from private to protected to
access from child class.

Change-Id: I04c05d432094c4d46216fcca58f776b0e6e7863c