### PR TITLE
DcTracker: Change access modifier of isNvSubscription to protected

### DIFF
--- a/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
@@ -1234,7 +1234,7 @@ public class DcTracker extends Handler {
         setupDataOnConnectableApns(Phone.REASON_DATA_ATTACHED);
     }
 
-    private boolean isNvSubscription() {
+    protected boolean isNvSubscription() {
         int cdmaSubscriptionSource = CdmaSubscriptionSourceManager.getDefault(mPhone.getContext());
         return cdmaSubscriptionSource == CdmaSubscriptionSourceManager.SUBSCRIPTION_FROM_NV;
     }


### PR DESCRIPTION
 * This fixes the fatal exception that makes telephony crash on CDMA networks:

     E AndroidRuntime: java.lang.IllegalAccessError: Method 'boolean com.android.internal.telephony.dataconnection.DcTracker.isNvSubscription()' is inaccessible to class 'com.qualcomm.qti.internal.telephony.dataconnection.QtiDcTracker' (declaration of 'com.qualcomm.qti.internal.telephony.dataconnection.QtiDcTracker' appears in /system/framework/qti-telephony-common.jar)

REGRESSION-1912

Change-Id: Ice02949e4114b969ad639ffd12b61579c265f40c