### PR TITLE
Don't assume 3GPP as active app on CDMA with LTE device

### DIFF
--- a/src/java/com/android/internal/telephony/uicc/IccCardProxy.java
+++ b/src/java/com/android/internal/telephony/uicc/IccCardProxy.java
@@ -169,31 +169,17 @@ public class IccCardProxy extends Handler implements IccCard {
      */
     private void updateQuietMode() {
         synchronized (mLock) {
-            boolean oldQuietMode = mQuietMode;
             boolean newQuietMode;
             int cdmaSource = Phone.CDMA_SUBSCRIPTION_UNKNOWN;
-            boolean isLteOnCdmaMode = TelephonyManager.getLteOnCdmaModeStatic()
-                    == PhoneConstants.LTE_ON_CDMA_TRUE;
             if (mCurrentAppType == UiccController.APP_FAM_3GPP) {
                 newQuietMode = false;
                 if (DBG) log("updateQuietMode: 3GPP subscription -> newQuietMode=" + newQuietMode);
             } else {
-                if (isLteOnCdmaMode) {
-                    log("updateQuietMode: is cdma/lte device, force IccCardProxy into 3gpp mode");
-                    mCurrentAppType = UiccController.APP_FAM_3GPP;
-                }
                 cdmaSource = mCdmaSSM != null ?
                         mCdmaSSM.getCdmaSubscriptionSource() : Phone.CDMA_SUBSCRIPTION_UNKNOWN;
 
                 newQuietMode = (cdmaSource == Phone.CDMA_SUBSCRIPTION_NV)
-                        && (mCurrentAppType == UiccController.APP_FAM_3GPP2)
-                        && !isLteOnCdmaMode;
-                if (DBG) {
-                    log("updateQuietMode: cdmaSource=" + cdmaSource
-                            + " mCurrentAppType=" + mCurrentAppType
-                            + " isLteOnCdmaMode=" + isLteOnCdmaMode
-                            + " newQuietMode=" + newQuietMode);
-                }
+                        && (mCurrentAppType == UiccController.APP_FAM_3GPP2);
             }
 
             if (mQuietMode == false && newQuietMode == true) {
@@ -214,8 +200,7 @@ public class IccCardProxy extends Handler implements IccCard {
             }
             if (DBG) {
                 log("updateQuietMode: QuietMode is " + mQuietMode + " (app_type="
-                    + mCurrentAppType + " isLteOnCdmaMode=" + isLteOnCdmaMode
-                    + " cdmaSource=" + cdmaSource + ")");
+                    + mCurrentAppType + " cdmaSource=" + cdmaSource + ")");
             }
             mInitialized = true;
             sendMessage(obtainMessage(EVENT_ICC_CHANGED));


### PR DESCRIPTION
IccCardProxy assumes, that on a CDMA+LTE device, the active app
is the SIM/USIM and not the RUIM/CSIM. However, for voice RUIM/CSIM
is the active app on such a device. All services, like FDN,etc. should
be tied to the active voice app.

Bug: 22931195
Change-Id: Ib1a3440c01b55a3be6ec8271dc69b3001ea65861
(cherry picked from commit a635fd92e8022f103fde2e8728b312b2cb8fa0c6)