### PR TITLE
IMS: Sudden deregisteration takes place soon after registeration.

### DIFF
--- a/src/java/com/android/internal/telephony/GsmCdmaPhone.java
+++ b/src/java/com/android/internal/telephony/GsmCdmaPhone.java
@@ -2226,8 +2226,12 @@ public class GsmCdmaPhone extends Phone {
                         config_switch_phone_on_voice_reg_state_change)) {
                     mCi.getVoiceRadioTechnology(obtainMessage(EVENT_REQUEST_VOICE_RADIO_TECH_DONE));
                 }
-                // Force update IMS service
-                ImsManager.getInstance(mContext, mPhoneId).updateImsServiceConfigForSlot(true);
+                if (getIccRecordsLoaded()) {
+                    // Force update IMS service
+                    ImsManager.getInstance(mContext, mPhoneId).updateImsServiceConfigForSlot(true);
+                } else {
+                    logw("received EVENT_CARRIER_CONFIG_CHANGED but IccRecords are not loaded");
+                }
 
                 // Update broadcastEmergencyCallStateChanges
                 CarrierConfigManager configMgr = (CarrierConfigManager)
@@ -3491,6 +3495,10 @@ public class GsmCdmaPhone extends Phone {
 
     private void loge(String s) {
         Rlog.e(LOG_TAG, "[GsmCdmaPhone] " + s);
+    }
+
+    private void logw(String s) {
+        Rlog.w(LOG_TAG, "[GsmCdmaPhone] " + s);
     }
 
     @Override


### PR DESCRIPTION
- As per new design, sub id is generated soon after iccid is loaded but before
  mmc/mnc info is actually available for the subs. Hence due to unavailability
  of proper mcc/mnc carrier config loads the default values for each subId .At
  the same the GsmCdma phone tries to update ims feature tags as but ends up
  loading default values as mcc-mnc info is still not present even if we have
  proper sub id.This leads to de-registeration. After some time when mcc-mnc
  and icc records are properly loaded , we get proper carrier config values
  for each sub and ims registration takes place for proper feature tags.

- After we get EVENT_CARRIER_CONFIG_CHANGED we update feature tags only
  if icc records are loaded .

CRs-Fixed: 2117394

Change-Id: Icbe2377daa4c9a92df1ac7c797fc581a9195052b