### PR TITLE
TelephonyComponentFactory: Fix SubscriptionInfoUpdater overloading

### DIFF
--- a/src/java/com/android/internal/telephony/TelephonyComponentFactory.java
+++ b/src/java/com/android/internal/telephony/TelephonyComponentFactory.java
@@ -222,7 +222,7 @@ public class TelephonyComponentFactory {
     public SubscriptionInfoUpdater makeSubscriptionInfoUpdater(Context context, Phone[] phones,
             CommandsInterface[] ci) {
         Rlog.d(LOG_TAG, "makeSubscriptionInfoUpdater");
-        return new SubscriptionInfoUpdater(BackgroundThread.get().getLooper(), context, phones, ci);
+        return makeSubscriptionInfoUpdater(BackgroundThread.get().getLooper(), context, phones, ci);
     }
 
     public SubscriptionInfoUpdater makeSubscriptionInfoUpdater(Looper looper, Context context,


### PR DESCRIPTION
* To make this work with both 8.0 and 8.1 QTI blobs, we need
  to make the default function with 3 args call the function
  with 4 args, because 8.0 QTI blobs overload the function
  with 3 args, but 8.1 QTI blobs overload the function with 4

Change-Id: Idb78221a1627d030c63e39312fb61f80adb1c782